### PR TITLE
Make the result file path(s) configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /work
 /.classpath
 /.project
+/.idea
 /bin
+/*.iml

--- a/src/main/java/blackboard/test/jenkins/jmhbenchmark/BenchmarkPublisher.java
+++ b/src/main/java/blackboard/test/jenkins/jmhbenchmark/BenchmarkPublisher.java
@@ -34,21 +34,26 @@ public class BenchmarkPublisher extends Recorder
   private final int _performanceDegradationThreshold;
   private final int _decimalPlaces;
   private final int _baselineBuildNumber;
+  private final String _resultFiles;
+
   private ReportParser _parser;
   private static final String BENCHMARK_OUTPUT_FOLDER = "jmh_benchmark_result";
   private static final String BENCHMARK_MODE_THRPT = "thrpt";
+
   private static String BUILD_PROJECT_NAME;
   // two decimal places are used to set changes from previous or baseline build
   private static final int MULTIPLIER = 100;
 
   @DataBoundConstructor
-  public BenchmarkPublisher( int performanceIncreaseThreshold, int performanceDegradationThreshold, int decimalPlaces,
-                             int baselineBuildNumber )
+  public BenchmarkPublisher(String resultFiles,
+                            int performanceIncreaseThreshold, int performanceDegradationThreshold, int decimalPlaces,
+                            int baselineBuildNumber)
   {
     _performanceIncreaseThreshold = performanceIncreaseThreshold;
     _performanceDegradationThreshold = performanceDegradationThreshold;
     _decimalPlaces = decimalPlaces;
     _baselineBuildNumber = baselineBuildNumber;
+    _resultFiles = resultFiles;
   }
 
   public int getDecimalPlaces()
@@ -86,7 +91,8 @@ public class BenchmarkPublisher extends Recorder
       return true;
     }
 
-    FilePath[] files = build.getWorkspace().list( "*.csv" );
+    FilePath[] files = build.getWorkspace().list(_resultFiles);
+
     if ( files.length <= 0 )
     {
       build.setResult( Result.FAILURE );

--- a/src/main/resources/blackboard/test/jenkins/jmhbenchmark/BenchmarkPublisher/config.jelly
+++ b/src/main/resources/blackboard/test/jenkins/jmhbenchmark/BenchmarkPublisher/config.jelly
@@ -8,6 +8,10 @@
     When submitted, it will be passed to the corresponding constructor parameter.
   -->
 
+  <f:entry title="JMH Result Files" description="An Ant-style file pattern for JMH results in CSV format">
+    <f:textbox field="resultFiles" default="**/jmh/*.csv" />
+  </f:entry>
+
   <f:entry title="Baseline Build Number">
     <f:textbox field="baselineBuildNumber" default="0" />
   </f:entry>


### PR DESCRIPTION
This should solve #2 

It simply adds a text field where the report file path (~ include pattern) can be specified.
Paths with wildcards should work fine (for example "**/jmh/*.csv")