### PR TITLE
Updates BenchmarkPublisher to look for .csv on subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.classpath
 /.project
 /bin
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>jmhbenchmark</artifactId>
-  <version>0.1</version>
+  <version>0.2</version>
   <packaging>hpi</packaging>
 
   <licenses>

--- a/src/main/java/blackboard/test/jenkins/jmhbenchmark/BenchmarkPublisher.java
+++ b/src/main/java/blackboard/test/jenkins/jmhbenchmark/BenchmarkPublisher.java
@@ -86,7 +86,7 @@ public class BenchmarkPublisher extends Recorder
       return true;
     }
 
-    FilePath[] files = build.getWorkspace().list( "*.csv" );
+    FilePath[] files = searchCsv(build, "*.csv", logger);
     if ( files.length <= 0 )
     {
       build.setResult( Result.FAILURE );
@@ -207,7 +207,23 @@ public class BenchmarkPublisher extends Recorder
     return true;
   }
 
-  private AbstractBuild<?, ?> getBaselineBuild( AbstractBuild<?, ?> build )
+  private FilePath[] searchCsv(AbstractBuild<?, ?> build, String pattern, PrintStream logger) throws IOException, InterruptedException {
+	FilePath[] files = build.getWorkspace().list(pattern);
+    if (files.length <= 0) {
+      logger.println("JMH Benchmark: failed to find results on root directory. Will look into subdirectories.");
+      // Look inside subdirectories
+	  List<FilePath> dirs = build.getWorkspace().listDirectories();
+	  for (FilePath dir : dirs) {
+	    logger.println("JMH Benchmark: Searching [" + dir.getBaseName() + "]");
+		files = dir.list("*.csv");
+		if (files.length > 0)
+		  return files;
+		}
+    }
+    return files;
+  }
+
+private AbstractBuild<?, ?> getBaselineBuild( AbstractBuild<?, ?> build )
   {
     if ( _baselineBuildNumber == 0 )
       return null;


### PR DESCRIPTION
Motivation:
On multi-module projects the JMH tests may actually be on one of the child projects and this plugin currently only searches for the .csv generated by JHM on the root folder.

Modifications:
Created a searchCsv method on BenchmarkPublisher that will look inside all subdirectories and search for the CSV file with JMH results.

Result:
CSV file is found.